### PR TITLE
Modify markdowntowp regex to recognize ** or __ for bold

### DIFF
--- a/readme-convertor.sh
+++ b/readme-convertor.sh
@@ -55,7 +55,7 @@ markdowntowp () {
     PLUGINMETA=("Contributors" "Donate link" "Donate Link" "Tags" "Requires at least" "Tested up to" "Stable tag" "License" "License URI")
     for m in "${PLUGINMETA[@]}"
     do
-        _sed 's/^\*\*'"$m"':\*\*/'"$m"':/g' $2
+        _sed 's/^(\*\*|__)'"$m"':(\*\*|__)/'"$m"':/g' $2
     done
 
     _sed "s/###([^#]+)###/=\1=/g" $2


### PR DESCRIPTION
Extended markdown processing of plugin meta to handle both `**Contributors**` and `__Contributors__` syntaxes (I find the latter more readable, as in [this readme](https://raw.github.com/acusti/simple-footnotes-editor-button/master/readme.md))

Also, thanks for creating and sharing these fantastic build / deploy scripts! They make me very happy. :+1:
